### PR TITLE
詳細動画表示画面に関連動画表示機能を追加

### DIFF
--- a/app/controllers/api/v1/videos_controller.rb
+++ b/app/controllers/api/v1/videos_controller.rb
@@ -28,7 +28,12 @@ class Api::V1::VideosController < ApplicationController
 
   # GET /api/v1/videos/:id
   def show
-    render json: { video: serialize_video(@video) }
+    related_videos = RelatedVideosService.new(@video).call
+    
+    render json: { 
+      video: serialize_video(@video),
+      related_videos: related_videos.map { |video| serialize_related_video(video) }
+    }
   end
 
   # GET /api/v1/videos/by_liver
@@ -134,5 +139,21 @@ class Api::V1::VideosController < ApplicationController
   def format_date(date)
     return "" if date.nil?
     date.strftime("%Y年%m月%d日")
+  end
+
+  def serialize_related_video(video)
+    {
+      id: video.id,
+      title: video.title,
+      thumbnail_url: video.thumbnail_url,
+      duration_seconds: video.duration_seconds,
+      duration_formatted: format_duration(video.duration_seconds),
+      view_count: video.view_count,
+      view_count_formatted: format_view_count(video.view_count),
+      published_at: video.published_at,
+      published_at_formatted: format_date(video.published_at),
+      youtube_url: video.youtube_url,
+      liver_name: video.livers.first&.display_name
+    }
   end
 end

--- a/app/controllers/api/v1/videos_controller.rb
+++ b/app/controllers/api/v1/videos_controller.rb
@@ -29,8 +29,8 @@ class Api::V1::VideosController < ApplicationController
   # GET /api/v1/videos/:id
   def show
     related_videos = RelatedVideosService.new(@video).call
-    
-    render json: { 
+
+    render json: {
       video: serialize_video(@video),
       related_videos: related_videos.map { |video| serialize_related_video(video) }
     }

--- a/app/services/related_videos_service.rb
+++ b/app/services/related_videos_service.rb
@@ -1,0 +1,24 @@
+class RelatedVideosService
+  def initialize(current_video, limit: 10)
+    @current_video = current_video
+    @limit = limit
+  end
+
+  def call
+    current_liver_ids = @current_video.livers.pluck(:id)
+    
+    available_livers = Liver.where.not(display_name: [nil, ""])
+                           .where.not(id: current_liver_ids)
+                           .order("RANDOM()")
+                           .limit(5)
+    
+    related_videos = []
+    available_livers.each do |liver|
+      videos = liver.videos.order(published_at: :desc).limit(3)
+      related_videos.concat(videos.to_a)
+      break if related_videos.size >= @limit
+    end
+    
+    related_videos.first(@limit)
+  end
+end

--- a/app/services/related_videos_service.rb
+++ b/app/services/related_videos_service.rb
@@ -6,19 +6,19 @@ class RelatedVideosService
 
   def call
     current_liver_ids = @current_video.livers.pluck(:id)
-    
-    available_livers = Liver.where.not(display_name: [nil, ""])
+
+    available_livers = Liver.where.not(display_name: [ nil, "" ])
                            .where.not(id: current_liver_ids)
                            .order("RANDOM()")
                            .limit(5)
-    
+
     related_videos = []
     available_livers.each do |liver|
       videos = liver.videos.order(published_at: :desc).limit(3)
       related_videos.concat(videos.to_a)
       break if related_videos.size >= @limit
     end
-    
+
     related_videos.first(@limit)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,15 +1,3 @@
-# This file is auto-generated from the current state of the database. Instead
-# of editing this file, please use the migrations feature of Active Record to
-# incrementally modify your database, and then regenerate this schema definition.
-#
-# This file is the source Rails uses to define your schema when running `bin/rails
-# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
-# be faster and is potentially less error prone than running all of your
-# migrations from scratch. Old migrations may fail to apply correctly if those
-# migrations use external dependencies or application code.
-#
-# It's strongly recommended that you check this file into your version control system.
-
 ActiveRecord::Schema[8.0].define(version: 5) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"


### PR DESCRIPTION
## 概要
詳細動画表示画面（`/api/v1/videos/:id` エンドポイント）に関連動画表示機能を追加しました。livers テーブルの display_name からランダムで選択した配信者の動画を抽出し、JSON応答に含めます。

## 変更内容
- **RelatedVideosService** クラスを新規作成
  - livers テーブルから display_name が存在するレコードをランダム選択
  - 現在の動画に関連する配信者を除外
  - 選択された配信者の動画を最新順で取得
- **VideosController#show** アクションを更新
  - 関連動画情報を JSON 応答に追加
  - `serialize_related_video` メソッドを追加

## API応答の変更
### 変更前
```json
{
  "video": {
    "id": 123,
    "title": "動画タイトル",
    ...
  }
}
```

### 変更後
```json
{
  "video": {
    "id": 123,
    "title": "動画タイトル",
    ...
  },
  "related_videos": [
    {
      "id": 456,
      "title": "関連動画1",
      "thumbnail_url": "...",
      "liver_name": "配信者名",
      ...
    }
  ]
}
```

## 実装詳細
- 最大10件の関連動画を返却（デフォルト設定）
- 最大5人の配信者から動画を取得
- 各配信者につき最大3件の動画を取得
- 現在の動画と同じ配信者の動画は除外

Closes #12

🤖 Generated with [Claude Code](https://claude.ai/code)